### PR TITLE
Add real-time persist for HN updates

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,9 @@
+# Exclude the target directory to speed up build
+target/
+
+# Exclude environment files that may contain sensitive information
+.env
+
+# Exclude any logs or temp files
+*.log
+*.tmp

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
  "gimli",
 ]
@@ -48,24 +48,23 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
- "is-terminal",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
 
 [[package]]
 name = "anstyle-parse"
@@ -87,9 +86,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
+checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
 dependencies = [
  "anstyle",
  "windows-sys 0.48.0",
@@ -200,9 +199,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
 dependencies = [
  "addr2line",
  "cc",
@@ -221,9 +220,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.2"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+checksum = "414dcefbc63d77c526a76b3afcf6fbb9b5e2791c19c3aa2297733208750c6e53"
 
 [[package]]
 name = "base64ct"
@@ -341,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.23"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03aef18ddf7d879c15ce20f04826ef8418101c7e528014c3eeea13321047dca3"
+checksum = "1d5f1946157a96594eb2d2c10eb7ad9a2b27518cb3000209dec700c35df9197d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -352,9 +351,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.23"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ce6fffb678c9b80a70b6b6de0aad31df727623a70fd9a842c30cd573e2fa98"
+checksum = "78116e32a042dd73c2901f0dc30790d20ff3447f3e3472fad359e8c3d282bcd6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -364,9 +363,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.3.12"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
+checksum = "c9fd1a5729c4548118d7d70ff234a44868d00489a4b6597b0b020918a0e91a1a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -376,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
 name = "colorchoice"
@@ -594,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7a532c1f99a0f596f6960a60d1e119e91582b24b39e2d83a190e61262c3ef0c"
+checksum = "d98235fdc2f355d330a8244184ab6b4b33c28679c0b4158f63138e51d6cf7e88"
 dependencies = [
  "bitflags 2.4.0",
  "byteorder",
@@ -622,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "diesel_derives"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74398b79d81e52e130d991afeed9c86034bb1b7735f46d2f5bf7deb261d80303"
+checksum = "e054665eaf6d97d1e7125512bb2d35d07c73ac86cc6920174cb42d1ab697a554"
 dependencies = [
  "diesel_table_macro_syntax",
  "proc-macro2",
@@ -692,9 +691,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.32"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
  "cfg-if",
 ]
@@ -711,6 +710,12 @@ dependencies = [
  "regex",
  "termcolor",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -978,9 +983,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.3"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
 name = "glob"
@@ -990,9 +995,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ec8491ebaf99c8eaa73058b045fe58073cd6be7f596ac993ced0b0a0c01049"
+checksum = "91fc23aa11be92976ef4729127f1a74adf36d8436f7816b185d18df956790833"
 dependencies = [
  "bytes",
  "fnv",
@@ -1000,7 +1005,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.9.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -1012,6 +1017,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "heck"
@@ -1181,7 +1192,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -1542,9 +1563,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+checksum = "77ac5bbd07aea88c60a577a1ce218075ffd59208b2d7ca97adf9bfc5aeb21ebe"
 dependencies = [
  "memchr",
 ]
@@ -1681,12 +1702,12 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "petgraph"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
+checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 2.0.0",
 ]
 
 [[package]]
@@ -1729,9 +1750,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -1751,7 +1772,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49b6c5ef183cd3ab4ba005f1ca64c21e8bd97ce4699cfea9e8d9a2c4958ca520"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.3",
  "byteorder",
  "bytes",
  "fallible-iterator",
@@ -1971,9 +1992,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.3"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
+checksum = "12de2eff854e5fa4b1295edd650e227e9d8fb0c9e90b12e7f36d6a6811791a29"
 dependencies = [
  "aho-corasick 1.0.4",
  "memchr",
@@ -1983,9 +2004,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
+checksum = "49530408a136e16e5b486e883fbb6ba058e8e4e8ae6621a77b048b314336e629"
 dependencies = [
  "aho-corasick 1.0.4",
  "memchr",
@@ -1994,17 +2015,17 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "reqwest"
-version = "0.11.18"
+version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
+checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.3",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2064,9 +2085,9 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.38.8"
+version = "0.38.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
+checksum = "9bfe0f2582b4931a45d1fa608f8a8722e8b3c7ac54dd6d5f3b3212791fedef49"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -2172,18 +2193,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.183"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.183"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2256,15 +2277,15 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "slab"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
@@ -2418,9 +2439,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fdd63d58b18d663fbdf70e049f00a22c8e42be082203be7f26589213cd75ea"
+checksum = "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48"
 dependencies = [
  "deranged",
  "serde",
@@ -2548,9 +2569,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "000387915083ea6406ee44b50ca74813aba799fe682a7689e382bf9e13b74ce9"
+checksum = "d340244b32d920260ae7448cb72b6e238bddc3d4f7603394e7dd46ed8e48f5b8"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -2616,7 +2637,7 @@ checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
  "async-trait",
  "axum",
- "base64 0.21.2",
+ "base64 0.21.3",
  "bytes",
  "futures-core",
  "futures-util",
@@ -2657,7 +2678,7 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
  "rand",
@@ -3096,11 +3117,12 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winreg"
-version = "0.10.1"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "winapi",
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -181,6 +181,10 @@ dependencies = [
  "eventsource-client 0.11.0",
  "firebase-rs",
  "futures",
+ "futures-util",
+ "hyper",
+ "hyper-openssl",
+ "hyper-tls",
  "log",
  "ndarray",
  "prost",
@@ -796,8 +800,6 @@ dependencies = [
 [[package]]
 name = "firebase-rs"
 version = "2.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "817b1ae8f94f4815a27c3b15d1afcc6ecbebb6afc43b4c3c0519b93e8893a2b8"
 dependencies = [
  "eventsource-client 0.10.2",
  "futures-util",
@@ -1097,6 +1099,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-openssl"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6ee5d7a8f718585d1c3c61dfde28ef5b0bb14734b4db13f5ada856cdc6c612b"
+dependencies = [
+ "http",
+ "hyper",
+ "linked_hash_set",
+ "once_cell",
+ "openssl",
+ "openssl-sys",
+ "parking_lot",
+ "tokio",
+ "tokio-openssl",
+ "tower-layer",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1276,6 +1296,21 @@ name = "libc"
 version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linked_hash_set"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47186c6da4d81ca383c7c47c1bfc80f4b95f4720514d860a5407aaf4233f9588"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -2496,6 +2531,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-openssl"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08f9ffb7809f1b20c1b398d92acf4cc719874b3b2b2d9ea2f09b4a80350878a"
+dependencies = [
+ "futures-util",
+ "openssl",
+ "openssl-sys",
  "tokio",
 ]
 

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -177,8 +177,7 @@ dependencies = [
  "diesel-async",
  "dotenv",
  "env_logger",
- "eventsource-client 0.11.0",
- "firebase-rs",
+ "eventsource-client",
  "flume",
  "futures",
  "futures-util",
@@ -751,21 +750,6 @@ dependencies = [
 
 [[package]]
 name = "eventsource-client"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9146112ee3ce031aa5aebe3e049e10b1d353b9c7630cc6be488c2c62cc5d9c42"
-dependencies = [
- "futures",
- "hyper",
- "hyper-rustls",
- "hyper-timeout",
- "log",
- "pin-project",
- "tokio",
-]
-
-[[package]]
-name = "eventsource-client"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b91e5ec5c794bbec5f639620f0bafe421b6d27dec66ac1ce3fdb6f009db3a6c"
@@ -802,19 +786,6 @@ dependencies = [
  "libc",
  "redox_syscall 0.3.5",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "firebase-rs"
-version = "2.0.8"
-dependencies = [
- "eventsource-client 0.10.2",
- "futures-util",
- "itertools 0.10.5",
- "reqwest",
- "serde",
- "serde_json",
- "url",
 ]
 
 [[package]]

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -179,6 +179,7 @@ dependencies = [
  "env_logger",
  "eventsource-client 0.11.0",
  "firebase-rs",
+ "flume",
  "futures",
  "futures-util",
  "hyper",
@@ -193,6 +194,7 @@ dependencies = [
  "thiserror",
  "tokenizers",
  "tokio",
+ "tokio-util",
  "tonic",
  "tonic-build",
 ]
@@ -832,6 +834,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -977,8 +991,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1469,6 +1485,15 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "native-tls"
@@ -2071,7 +2096,7 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
+ "spin 0.5.2",
  "untrusted",
  "web-sys",
  "winapi",
@@ -2321,6 +2346,15 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spm_precompiled"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -17,9 +17,13 @@ diesel = { version = "2.1.0", features = ["postgres"] }
 diesel-async = { version = "0.3.1", features = ["postgres", "deadpool" ]}
 dotenv = "0.15.0"
 env_logger = "0.10.0"
-eventsource-client = "0.11.0"
-firebase-rs = "2.0.8"
+eventsource-client = {version = "0.11.0"}
+firebase-rs = {version = "2.0.8", path = "../../firebase-rs"}
 futures = "0.3.28"
+futures-util = "0.3.28"
+hyper = "0.14.27"
+hyper-openssl = "0.9.2"
+hyper-tls = "0.5.0"
 log = "0.4.19"
 ndarray = "0.15.6"
 prost = "0.11.9"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -18,7 +18,6 @@ diesel-async = { version = "0.3.1", features = ["postgres", "deadpool" ]}
 dotenv = "0.15.0"
 env_logger = "0.10.0"
 eventsource-client = {version = "0.11.0"}
-firebase-rs = {version = "2.0.8", path = "../../firebase-rs"}
 flume = "0.11.0"
 futures = "0.3.28"
 futures-util = "0.3.28"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -19,6 +19,7 @@ dotenv = "0.15.0"
 env_logger = "0.10.0"
 eventsource-client = {version = "0.11.0"}
 firebase-rs = {version = "2.0.8", path = "../../firebase-rs"}
+flume = "0.11.0"
 futures = "0.3.28"
 futures-util = "0.3.28"
 hyper = "0.14.27"
@@ -33,6 +34,7 @@ serde_json = "1.0.103"
 thiserror = "1.0.44"
 tokenizers = "0.13.3"
 tokio = { version = "1.29.1", features = ["full"] }
+tokio-util = "0.7.8"
 tonic = "0.9.2"
 
 [build-dependencies]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,32 @@
+# Compile stage
+FROM rust:1.71.0 as builder
+# Set workdir in builder
+WORKDIR /usr/src/app
+
+# Dependency compile step (broken out for caching)
+# Copy Cargo.toml and Cargo.lock
+COPY Cargo.toml Cargo.lock ./
+# This is just to cache dependencies
+RUN cargo build --release 
+# Remove the built files, they are outdated now
+RUN rm -rf target/release/*
+
+# Copy whole Rust project in, do the actual build
+COPY . . 
+# Install client dependencies
+RUN apt-get update && apt-get install -y libssl-dev libpq-dev
+# Build app
+RUN cargo build --release
+
+# Runtime stage
+FROM debian:buster-slim
+# Set logging
+ENV RUST_LOG=info
+# Install runtime dependencies for OpenSSL and Postgres
+RUN apt-get update && \
+    apt-get install -y libssl1.1 libpq5 && \
+    rm -rf /var/lib/apt/lists/*
+# Copy in the backend binary
+COPY --from=builder /usr/src/app/target/release/backend /usr/local/bin
+EXPOSE 3000
+CMD ["RUST_LOG=info backend"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,27 +6,28 @@ WORKDIR /usr/src/app
 # Dependency compile step (broken out for caching)
 # Copy Cargo.toml and Cargo.lock
 COPY Cargo.toml Cargo.lock ./
+# Create dummy files just to fulfill lib and bin crates
+RUN echo "fn main() {}" > main.rs
+RUN mkdir lib && echo "pub fn lib() {}" > lib/lib.rs
 # This is just to cache dependencies
 RUN cargo build --release 
 # Remove the built files, they are outdated now
-RUN rm -rf target/release/*
-
-# Copy whole Rust project in, do the actual build
-COPY . . 
-# Install client dependencies
-RUN apt-get update && apt-get install -y libssl-dev libpq-dev
-# Build app
-RUN cargo build --release
+# RUN rm -rf target/release/*
+RUN rm main.rs && rm -rf lib
+COPY . .
+RUN apt-get update && \
+    apt-get install -y protobuf-compiler
+RUN cargo build --release 
 
 # Runtime stage
-FROM debian:buster-slim
+FROM debian:bullseye
 # Set logging
 ENV RUST_LOG=info
 # Install runtime dependencies for OpenSSL and Postgres
 RUN apt-get update && \
-    apt-get install -y libssl1.1 libpq5 && \
+    apt-get install -y libssl1.1 libpq5 protobuf-compiler curl && \
     rm -rf /var/lib/apt/lists/*
 # Copy in the backend binary
 COPY --from=builder /usr/src/app/target/release/backend /usr/local/bin
 EXPOSE 3000
-CMD ["RUST_LOG=info backend"]
+CMD ["backend"]

--- a/backend/lib/db/models.rs
+++ b/backend/lib/db/models.rs
@@ -56,3 +56,11 @@ impl From<listener::Item> for Item {
         }
     }
 }
+
+#[derive(Queryable, Insertable, AsChangeset)]
+#[diesel(table_name = super::schema::kids)]
+pub struct Kid {
+    pub item: i64,
+    pub kid: i64,
+    pub display_order: Option<i64>,
+}

--- a/backend/lib/firebase_listener/listener.rs
+++ b/backend/lib/firebase_listener/listener.rs
@@ -1,8 +1,11 @@
 use firebase_rs::Firebase;
+use futures_util::StreamExt;
+use log::debug;
 use reqwest;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self};
 use thiserror::Error;
+use tokio::sync::mpsc;
 
 pub struct FirebaseListener {
     /// TODO: Make this a connection pool if it becomes a bottleneck!
@@ -30,6 +33,18 @@ pub struct Item {
     pub kids: Option<Vec<i64>>,
 }
 
+#[derive(Deserialize, Serialize, Debug)]
+pub struct UpdateData {
+    pub items: Option<Vec<i64>>,
+    pub profiles: Option<Vec<String>>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct Update {
+    pub path: String,
+    pub data: UpdateData,
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 pub struct User {
     pub id: String,
@@ -43,6 +58,7 @@ pub struct User {
 pub enum FirebaseListenerErr {
     ConnectError(String),
     ParseError(String),
+    JsonParseError(#[from] serde_json::Error), // Added for JSON parsing errors
 }
 
 impl fmt::Display for FirebaseListenerErr {
@@ -50,13 +66,14 @@ impl fmt::Display for FirebaseListenerErr {
         match self {
             FirebaseListenerErr::ConnectError(e) => write!(f, "ConnectError: {}", e),
             FirebaseListenerErr::ParseError(e) => write!(f, "ParseError: {}", e),
+            FirebaseListenerErr::JsonParseError(e) => write!(f, "ParseError: {}", e),
         }
     }
 }
 
 impl FirebaseListener {
-    pub fn new(url: &str) -> Result<Self, FirebaseListenerErr> {
-        let firebase = Firebase::new(url).map_err(|_| {
+    pub fn new(url: String) -> Result<Self, FirebaseListenerErr> {
+        let firebase = Firebase::new(&url).map_err(|_| {
             FirebaseListenerErr::ConnectError(format!("Could not connect to URL {}", url))
         })?;
         let client = reqwest::Client::new();
@@ -108,5 +125,42 @@ impl FirebaseListener {
             .await
             .map_err(|_| FirebaseListenerErr::ParseError("Invalid response for max item".into()))?;
         Ok(max_id)
+    }
+
+    pub async fn listen_to_updates(
+        &self,
+        sender: mpsc::Sender<UpdateData>,
+    ) -> Result<(), FirebaseListenerErr> {
+        let mut stream = self
+            .firebase
+            .at("updates")
+            .with_realtime_events()
+            .ok_or(FirebaseListenerErr::ConnectError(format!(
+                "Could not connect to events for {}",
+                &self.base_url
+            )))? // Handle connection error
+            .stream(true);
+
+        while let Some(event) = stream.next().await {
+            match event {
+                Ok((event_type, maybe_data)) => match maybe_data {
+                    Some(s) => match serde_json::from_str::<Update>(&s) {
+                        Ok(update) => {
+                            debug!("{:?} {:?}", event_type, update.data);
+                            if let Err(err) = sender.send(update.data).await {
+                                println!("Error sending update data: {:?}", err);
+                            };
+                        }
+                        Err(err) => {
+                            // Handle JSON parsing error
+                            println!("Error parsing JSON for event {:?}: {:?}", event_type, err);
+                        }
+                    },
+                    None => println!("{:?} {:?}", event_type, maybe_data),
+                },
+                Err(err) => println!("{:?}", err),
+            }
+        }
+        Ok(())
     }
 }

--- a/backend/lib/sync_service/mod.rs
+++ b/backend/lib/sync_service/mod.rs
@@ -3,13 +3,13 @@ use diesel::insert_into;
 use diesel::pg::upsert::excluded;
 use diesel::prelude::*;
 use diesel::result::Error as DieselError;
-use diesel_async::pooled_connection::deadpool::Pool;
+use diesel_async::pooled_connection::deadpool::{Pool, PoolError};
 use diesel_async::RunQueryDsl;
 use futures::future::join_all;
 use log::{debug, info};
 use std::vec;
 use thiserror::Error;
-use tokio::task::spawn;
+use tokio::task::{spawn, JoinError};
 
 use crate::db::models;
 use crate::db::schema::items;
@@ -26,6 +26,12 @@ pub enum Error {
 
     #[error(transparent)]
     DieselError(#[from] DieselError),
+
+    #[error(transparent)]
+    DBPoolError(#[from] PoolError),
+
+    #[error("Task join error: {0}")]
+    TaskJoinError(#[from] JoinError),
 }
 
 pub struct SyncService {
@@ -105,7 +111,9 @@ impl SyncService {
         ))?;
         let min_id = match n_start {
             Some(n) => n,
-            None => max_db_item,
+            // TODO: Make this constant less arbitrary
+            // About a day and a half of data
+            None => max_db_item - 25_000,
         };
         let max_id = match n_additional {
             Some(n) => min_id + n,
@@ -120,8 +128,17 @@ impl SyncService {
         for range in id_ranges.into_iter() {
             let db_pool = self.db_pool.clone();
             let fb_url = self.firebase_url.clone();
-            let handle =
-                spawn(async move { catchup_worker(&fb_url, range.0, range.1, db_pool).await });
+            let handle = spawn(async move {
+                worker(
+                    &fb_url,
+                    Some(range.0),
+                    Some(range.1),
+                    db_pool,
+                    WorkerMode::Catchup,
+                    None,
+                )
+                .await
+            });
             handles.push(handle);
         }
 
@@ -142,74 +159,136 @@ impl SyncService {
     }
 
     /// Realtime subscription to HN item updates
-    pub async fn realtime_update(&self) -> Result<(), Error> {
+    pub async fn realtime_update(
+        &self,
+        num_workers: usize,
+        receiver: flume::Receiver<i64>,
+    ) -> Result<(), Error> {
+        info!("Spawning {} realtime update workers...", num_workers);
+        let mut update_worker_handles = Vec::new();
+        for _ in 0..num_workers {
+            let worker_receiver = receiver.clone();
+            let firebase_url = self.firebase_url.clone();
+            let db_pool = self.db_pool.clone();
+            let handle = tokio::spawn(async move {
+                worker(
+                    &firebase_url,
+                    None,
+                    None,
+                    db_pool,
+                    WorkerMode::Updater,
+                    Some(worker_receiver),
+                )
+                .await
+            });
+            update_worker_handles.push(handle);
+        }
+        info!("Successfully spawned all realtime update workers.");
         Ok(())
     }
-
-    // possibly the wrong place to put this lmao
 }
 
-async fn catchup_worker(
-    firebase_url: &str,
-    min_id: i64,
-    max_id: i64,
-    pool: Pool<diesel_async::AsyncPgConnection>,
+async fn download_item(
+    fb: &FirebaseListener,
+    id: i64,
+    items_batch: &mut Vec<models::Item>,
+    kids_batch: &mut Vec<models::Kid>,
 ) -> Result<(), Error> {
+    let raw_item = fb.get_item(id).await?;
+    if let Some(kids) = &raw_item.kids {
+        for (idx, kid) in kids.iter().enumerate() {
+            kids_batch.push(models::Kid {
+                item: *&raw_item.id,
+                kid: *kid,
+                display_order: Some(idx as i64),
+            })
+        }
+    }
+    let item = Into::<models::Item>::into(raw_item);
+    items_batch.push(item);
+    Ok(())
+}
+
+async fn upload_items(
+    pool: &Pool<diesel_async::AsyncPgConnection>,
+    items_batch: &mut Vec<models::Item>,
+    kids_batch: &mut Vec<models::Kid>,
+) -> Result<(), Error> {
+    let mut conn = pool.get().await?;
+    insert_into(items::dsl::items)
+        .values(&*items_batch)
+        .on_conflict(items::id)
+        .do_update()
+        .set((
+            items::deleted.eq(excluded(items::deleted)),
+            items::type_.eq(excluded(items::type_)),
+            items::by.eq(excluded(items::by)),
+            items::time.eq(excluded(items::time)),
+            items::text.eq(excluded(items::text)),
+            items::dead.eq(excluded(items::dead)),
+            items::parent.eq(excluded(items::parent)),
+            items::poll.eq(excluded(items::poll)),
+            items::url.eq(excluded(items::url)),
+            items::score.eq(excluded(items::score)),
+            items::title.eq(excluded(items::title)),
+            items::parts.eq(excluded(items::parts)),
+            items::descendants.eq(excluded(items::descendants)),
+        ))
+        .execute(&mut conn)
+        .await?;
+    items_batch.clear();
+
+    insert_into(kids::dsl::kids)
+        .values(&*kids_batch)
+        .on_conflict((kids::item, kids::kid))
+        .do_update()
+        .set(kids::display_order.eq(excluded(kids::display_order)))
+        .execute(&mut conn)
+        .await?;
+    kids_batch.clear();
+    Ok(())
+}
+
+enum WorkerMode {
+    Catchup,
+    Updater,
+}
+
+async fn worker(
+    firebase_url: &str,
+    min_id: Option<i64>,
+    max_id: Option<i64>,
+    pool: Pool<diesel_async::AsyncPgConnection>,
+    mode: WorkerMode,
+    receiver: Option<flume::Receiver<i64>>,
+) -> Result<(), Error> {
+    // TODO: Magic number, fix this
     const FLUSH_INTERVAL: usize = 1000;
-    let mut conn = pool.get().await.unwrap();
     let fb = FirebaseListener::new(firebase_url.to_string())
         .map_err(|_| Error::ConnectError("HALP".into()))?;
 
     let mut items_batch: Vec<models::Item> = Vec::new();
     let mut kids_batch: Vec<models::Kid> = Vec::new();
 
-    for i in min_id..=max_id {
-        let raw_item = fb.get_item(i).await?;
-        if let Some(kids) = &raw_item.kids {
-            for (idx, kid) in kids.iter().enumerate() {
-                kids_batch.push(models::Kid {
-                    item: *&raw_item.id,
-                    kid: *kid,
-                    display_order: Some(idx as i64),
-                })
+    match mode {
+        WorkerMode::Catchup => {
+            if let (Some(min_id), Some(max_id)) = (min_id, max_id) {
+                for i in min_id..=max_id {
+                    download_item(&fb, i, &mut items_batch, &mut kids_batch).await?;
+                    if items_batch.len() == FLUSH_INTERVAL || i == max_id {
+                        info!("Pushing {} to {}", (i - items_batch.len() as i64), i);
+                        upload_items(&pool, &mut items_batch, &mut kids_batch).await?;
+                    }
+                }
             }
         }
-        let item = Into::<models::Item>::into(raw_item);
-        items_batch.push(item);
-
-        if items_batch.len() == FLUSH_INTERVAL || i == max_id {
-            info!("Pushing {} to {}", (i - items_batch.len() as i64), i);
-            insert_into(items::dsl::items)
-                .values(&items_batch)
-                .on_conflict(items::id)
-                .do_update()
-                .set((
-                    items::deleted.eq(excluded(items::deleted)),
-                    items::type_.eq(excluded(items::type_)),
-                    items::by.eq(excluded(items::by)),
-                    items::time.eq(excluded(items::time)),
-                    items::text.eq(excluded(items::text)),
-                    items::dead.eq(excluded(items::dead)),
-                    items::parent.eq(excluded(items::parent)),
-                    items::poll.eq(excluded(items::poll)),
-                    items::url.eq(excluded(items::url)),
-                    items::score.eq(excluded(items::score)),
-                    items::title.eq(excluded(items::title)),
-                    items::parts.eq(excluded(items::parts)),
-                    items::descendants.eq(excluded(items::descendants)),
-                ))
-                .execute(&mut conn)
-                .await?;
-            items_batch.clear();
-
-            insert_into(kids::dsl::kids)
-                .values(&kids_batch)
-                .on_conflict((kids::item, kids::kid))
-                .do_update()
-                .set(kids::display_order.eq(excluded(kids::display_order)))
-                .execute(&mut conn)
-                .await?;
-            kids_batch.clear();
+        WorkerMode::Updater => {
+            let receiver = receiver.ok_or(Error::ConnectError("No channel provided!".into()))?;
+            while let Ok(id) = receiver.recv_async().await {
+                download_item(&fb, id, &mut items_batch, &mut kids_batch).await?;
+                debug!("Pushing {}", id);
+                upload_items(&pool, &mut items_batch, &mut kids_batch).await?;
+            }
         }
     }
     Ok(())

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -3,6 +3,7 @@ use backend_lib::{
     config::Config, db, firebase_listener::FirebaseListener, sync_service::SyncService,
 };
 use std::time::Instant;
+use tokio::sync::mpsc;
 
 use clap::Parser;
 use diesel::dsl::max;
@@ -11,6 +12,8 @@ use diesel_async::pooled_connection::deadpool::Pool;
 use diesel_async::pooled_connection::AsyncDieselConnectionManager;
 use diesel_async::RunQueryDsl;
 use dotenv::dotenv;
+use firebase_rs::Firebase;
+use futures_util::StreamExt;
 use log::{debug, info};
 
 #[derive(Parser, Debug)]
@@ -37,7 +40,7 @@ async fn main() {
     // let args = Cli::parse();
     debug!("Config loaded");
 
-    let fb = FirebaseListener::new(&config.hn_api_url).unwrap();
+    let fb = FirebaseListener::new(config.hn_api_url.clone()).unwrap();
     println!("{:?}", fb.get_max_id().await);
     let pool_config =
         AsyncDieselConnectionManager::<diesel_async::AsyncPgConnection>::new(&config.db_url);
@@ -46,7 +49,7 @@ async fn main() {
         .expect("Could not establish connection!");
 
     // Temporary
-    let sync_service = SyncService::new(config.hn_api_url, pool.clone(), 200);
+    let sync_service = SyncService::new(config.hn_api_url.clone(), pool.clone(), 200);
 
     let start_time = Instant::now();
     sync_service
@@ -55,7 +58,25 @@ async fn main() {
         .expect("Catchup failed");
     let elapsed_time = start_time.elapsed();
     info!("Catchup time elapsed: {:?}", elapsed_time);
+    let (sender, receiver) = mpsc::channel(32);
+    let hn_updates_handle = tokio::spawn(async move {
+        FirebaseListener::new(config.hn_api_url.clone())
+            .unwrap()
+            .listen_to_updates(sender)
+            .await
+            .expect("SSE has failed!");
+    });
+    hn_updates_handle
+        .await
+        .expect("SSE background update has panicked!");
     // let text: &str = "When I was a young boy, my father took me into the city to see a marching band";
+    /* let (sender, mut receiver) = mpsc::channel(32);
+    tokio::spawn(async move {
+        FirebaseListener::new(config.hn_api_url.clone())
+            .unwrap()
+            .listen_to_updates(sender)
+            .await
+    }); */
 
     /*
     let embedder = E5Embedder::new(&config.triton_server_addr)


### PR DESCRIPTION
This PR adds:
- Listening for updates
- Dockerfile for deployments (CI/CD incoming)
- Graceful shutdown logic
- Catchup mode to deal with updates from last day (this was a bug in the upstream!)

This PR fixes:
- Upsert mode (add kids)
- Dependency on monkey-patched version of firebase-rs (cuts out the dependency and uses underlying reqwest and eventsource crates)