### PR TITLE
Hotfix: Add BuildX to CI runner

### DIFF
--- a/.github/workflows/build-backend.yaml
+++ b/.github/workflows/build-backend.yaml
@@ -20,6 +20,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      
       - name: Login to GitHub Packages
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
Didn't realize buildx needed to be explicitly